### PR TITLE
Rails複数種類通知機能追加

### DIFF
--- a/6_0_0/ch14/app/controllers/account_activations_controller.rb
+++ b/6_0_0/ch14/app/controllers/account_activations_controller.rb
@@ -3,6 +3,7 @@ class AccountActivationsController < ApplicationController
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      Notification.create(:user_id => user.id, :action => 'login')
       user.update_attribute(:activated,    true)
       user.update_attribute(:activated_at, Time.zone.now)
       user.activate

--- a/6_0_0/ch14/app/controllers/static_pages_controller.rb
+++ b/6_0_0/ch14/app/controllers/static_pages_controller.rb
@@ -3,6 +3,7 @@ class StaticPagesController < ApplicationController
     if logged_in?
       @micropost  = current_user.microposts.build
       @feed_items = current_user.feed.paginate(page: params[:page])
+      @notifications = current_user.notification_list
     end
   end
 

--- a/6_0_0/ch14/app/models/notification.rb
+++ b/6_0_0/ch14/app/models/notification.rb
@@ -1,0 +1,4 @@
+class Notification < ApplicationRecord
+  default_scope -> { order(created_at: :asc) }
+  belongs_to :user, optional: true
+end

--- a/6_0_0/ch14/app/views/shared/_notification_list.html.erb
+++ b/6_0_0/ch14/app/views/shared/_notification_list.html.erb
@@ -1,0 +1,23 @@
+<h3>Notification</h3>
+
+<div>
+  <div>
+    <% if @notifications.present? %>
+        <ul>
+            <% @notifications.each do |notification| %>
+                <% if notification['action'] == 'login' %>
+                    <li>初回ログインありがとうございます。</li>
+                <% elsif notification['action'] == 'followed' %>
+                    <% if notification['count'] > 0 %>
+                        <li><%= notification['name'] %>さん他<%= notification['count'] %>名にフォローされました。</li>
+                    <% elsif notification['count'] == 0 %>
+                        <li><%= notification['name'] %>さんにフォローされました。</li>
+                    <% end %>
+                <% end %>
+            <% end %>
+        </ul>
+    <% else %>
+        <p>通知はありません</p>
+    <% end %>
+  </div>
+</div>

--- a/6_0_0/ch14/app/views/static_pages/home.html.erb
+++ b/6_0_0/ch14/app/views/static_pages/home.html.erb
@@ -10,6 +10,9 @@
       <section class="micropost_form">
         <%= render 'shared/micropost_form' %>
       </section>
+      <section class="notification_list">
+        <%= render 'shared/notification_list' %>
+      </section>
     </aside>
     <div class="col-md-8">
       <h3>Micropost Feed</h3>

--- a/6_0_0/ch14/db/migrate/20211125091748_create_notifications.rb
+++ b/6_0_0/ch14/db/migrate/20211125091748_create_notifications.rb
@@ -1,0 +1,11 @@
+class CreateNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notifications do |t|
+      t.integer :user_id
+      t.string  :action
+      t.integer :followed_id
+
+      t.timestamps
+    end
+  end
+end

--- a/6_0_0/ch14/db/schema.rb
+++ b/6_0_0/ch14/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_073601) do
+ActiveRecord::Schema.define(version: 2021_11_25_091748) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -40,6 +40,14 @@ ActiveRecord::Schema.define(version: 2020_02_18_073601) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id", "created_at"], name: "index_microposts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_microposts_on_user_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "action"
+    t.integer "followed_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "relationships", force: :cascade do |t|


### PR DESCRIPTION
## 目的

- 機能拡張を行いRails複数種類通知を追加します。

## 要件

- フォローされた際に通知が作られる（「○○さんにフォローされました」）
- 初回ログイン時に通知が作られる（「初回ログインありがとうございます。」）
- 1,2の通知を同じUIで一覧できる
- 5分以内に同じ種類の通知が発生する場合は一つの通知にまとめられる（「○○さん他3名にフォローされました」）

## 実装内容

- 通知情報テーブルのマイグレーションを追加しました。
- テーブル追加に伴いまして、schema.rbを更新しました。
- アクティベーション時の処理に初回ログイン通知情報登録処理を追加しました。
- ユーザトップ画面の表示処理に今回追加しました通知一覧の情報取得処理を追加しました。
- 通知情報テーブルのモデルを追加しました。
- ユーザテーブルのモデルに通知情報テーブルの関連情報を追加しました。
- ユーザテーブルのモデルのフォロー処理にフォロー通知情報登録処理を追加しました。
- ユーザテーブルのモデルにユーザトップ画面で表示する通知一覧情報を取得するメソッドを追加しました。
- 通知一覧表示HTMLを追加しました。
- ユーザトップ画面に通知一覧表示を追加しました。
